### PR TITLE
Enable operation on networks with 22/tcp closed publicly

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ docker-machine create --driver google \
     --google-disk-type pd-ssd \
     --google-disk-size ${var.ci_worker_disk_size} \
     --google-tags ${var.ci_worker_instance_tags} \
-    --google-use-internal-ip-only \
+    --google-use-internal-ip \
     ${var.gcp_resource_prefix}-test-machine
 
 docker-machine rm -y ${var.gcp_resource_prefix}-test-machine
@@ -130,7 +130,7 @@ sudo gitlab-runner register -n \
     --machine-machine-options "google-disk-type=pd-ssd" \
     --machine-machine-options "google-disk-size=${var.ci_worker_disk_size}" \
     --machine-machine-options "google-tags=${var.ci_worker_instance_tags}" \
-    --machine-machine-options "google-use-internal-ip-only" \
+    --machine-machine-options "google-use-internal-ip" \
     && true
 
 echo "GitLab CI Runner installation complete"

--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ docker-machine create --driver google \
     --google-disk-type pd-ssd \
     --google-disk-size ${var.ci_worker_disk_size} \
     --google-tags ${var.ci_worker_instance_tags} \
-    --google-use-internal-ip \
+    --google-use-internal-ip-only \
     ${var.gcp_resource_prefix}-test-machine
 
 docker-machine rm -y ${var.gcp_resource_prefix}-test-machine
@@ -130,6 +130,7 @@ sudo gitlab-runner register -n \
     --machine-machine-options "google-disk-type=pd-ssd" \
     --machine-machine-options "google-disk-size=${var.ci_worker_disk_size}" \
     --machine-machine-options "google-tags=${var.ci_worker_instance_tags}" \
+    --machine-machine-options "google-use-internal-ip-only" \
     && true
 
 echo "GitLab CI Runner installation complete"

--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,7 @@ docker-machine create --driver google \
     --google-disk-type pd-ssd \
     --google-disk-size ${var.ci_worker_disk_size} \
     --google-tags ${var.ci_worker_instance_tags} \
+    --google-use-internal-ip \
     ${var.gcp_resource_prefix}-test-machine
 
 docker-machine rm -y ${var.gcp_resource_prefix}-test-machine


### PR DESCRIPTION
Enable operation on networks with 22/tcp closed publicly by using internal IP to connect to docker-machine instances

Without this, if 22/tcp is restricted then docker-machine will hang on `Waiting for ssh to be available…` because it is attempting to connect with the external IP.