### PR TITLE
Explicitly specify google-machine-image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@
 # Compute the runner name to use for registration in GitLab.  We provide a default based on the GCP project name but it
 # can be overridden if desired.
 locals {
-  ci_runner_gitlab_name_final = (var.ci_runner_gitlab_name != "" ? var.ci_runner_gitlab_name : "gcp-${var.gcp_project}" )
+  ci_runner_gitlab_name_final = (var.ci_runner_gitlab_name != "" ? var.ci_runner_gitlab_name : "gcp-${var.gcp_project}")
 }
 
 # Service account for the Gitlab CI runner.  It doesn't run builds but it spawns other instances that do.
@@ -105,6 +105,7 @@ docker-machine create --driver google \
     --google-scopes https://www.googleapis.com/auth/cloud-platform \
     --google-disk-type pd-ssd \
     --google-disk-size ${var.ci_worker_disk_size} \
+    --google-machine-image ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20220419 \
     --google-tags ${var.ci_worker_instance_tags} \
     --google-use-internal-ip \
     ${var.gcp_resource_prefix}-test-machine
@@ -129,6 +130,7 @@ sudo gitlab-runner register -n \
     --machine-machine-name "${var.gcp_resource_prefix}-worker-%s" \
     --machine-machine-options "google-project=${var.gcp_project}" \
     --machine-machine-options "google-machine-type=${var.ci_worker_instance_type}" \
+    --machine-machine-options "google-machine-image ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20220419" \
     --machine-machine-options "google-zone=${var.gcp_zone}" \
     --machine-machine-options "google-service-account=${google_service_account.ci_worker.email}" \
     --machine-machine-options "google-scopes=https://www.googleapis.com/auth/cloud-platform" \

--- a/main.tf
+++ b/main.tf
@@ -130,7 +130,7 @@ sudo gitlab-runner register -n \
     --machine-machine-name "${var.gcp_resource_prefix}-worker-%s" \
     --machine-machine-options "google-project=${var.gcp_project}" \
     --machine-machine-options "google-machine-type=${var.ci_worker_instance_type}" \
-    --machine-machine-options "google-machine-image ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20220419" \
+    --machine-machine-options "google-machine-image=ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20220419" \
     --machine-machine-options "google-zone=${var.gcp_zone}" \
     --machine-machine-options "google-service-account=${google_service_account.ci_worker.email}" \
     --machine-machine-options "google-scopes=https://www.googleapis.com/auth/cloud-platform" \


### PR DESCRIPTION
Today, the Docker installation script dropped support for the old Ubuntu version (16.04 Xenial) which was used in docker-machine by default. See this answer for more information: https://stackoverflow.com/a/72026617/8704691

The PR explicitly specifies `google-machine-image` for docker-machine and sets it to Ubuntu 20.04 Focal. In the future, it might be a good idea to move this value into a variable.
