### PR TITLE
Add pre/post hook script variables.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,10 @@ sudo gitlab-runner register -n \
     --machine-machine-options "google-disk-size=${var.ci_worker_disk_size}" \
     --machine-machine-options "google-tags=${var.ci_worker_instance_tags}" \
     --machine-machine-options "google-use-internal-ip" \
+    %{if var.pre_clone_script != ""}--pre-clone-script ${replace(format("%q", var.pre_clone_script), "$", "\\$")}%{endif} \
+    %{if var.post_clone_script != ""}--post-clone-script ${replace(format("%q", var.post_clone_script), "$", "\\$")}%{endif} \
+    %{if var.pre_build_script != ""}--pre-build-script ${replace(format("%q", var.pre_build_script), "$", "\\$")}%{endif} \
+    %{if var.post_build_script != ""}--post-build-script ${replace(format("%q", var.post_build_script), "$", "\\$")}%{endif} \
     && true
 
 echo "GitLab CI Runner installation complete"

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,40 @@ variable "docker_privileged" {
   default     = "false"
   description = "Give extended privileges to container."
 }
+
+# Pre/post hook scripts
+variable "pre_clone_script" {
+  type        = string
+  default     = ""
+  description = <<EOF
+Commands to be executed on the runner before cloning the Git repository.
+NOTE: this script runs within the gitlab-runner helper image.
+EOF
+}
+
+variable "post_clone_script" {
+  type        = string
+  default     = ""
+  description = <<EOF
+Commands to be executed on the runner after cloning the Git repository.
+NOTE: this script runs within the gitlab-runner helper image.
+EOF
+}
+
+variable "pre_build_script" {
+  type        = string
+  default     = ""
+  description = <<EOF
+Commands to be executed on the runner before executing the build.
+NOTE: this script runs within the build image specified by .gitlab-ci.yml.
+EOF
+}
+
+variable "post_build_script" {
+  type        = string
+  default     = ""
+  description = <<EOF
+Commands to be executed on the runner after executing the build.
+NOTE: this script runs within the build image specified by .gitlab-ci.yml.
+EOF
+}


### PR DESCRIPTION
This adds support for `pre_clone_script`, `post_clone_script`, `pre_build_script`, and `post_build_script` options as described in the GitLab runner docs.

For more information, see
https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runners-section