### PR TITLE
Add a way to set subnetwork from variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,9 @@ resource "google_compute_instance" "ci_runner" {
   }
 
   network_interface {
-    network = var.ci_runner_network
+    network    = var.ci_runner_network
+    subnetwork = var.ci_runner_subnetwork
+
 
     access_config {
       // Ephemeral IP

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,13 @@ variable "ci_runner_network" {
   default = "default"
   description = "the network to add the runner on"
 }
+
+variable "ci_runner_subnetwork" {
+  type        = string
+  default     = ""
+  description = "the subnetwork to add the runner on"
+}
+
 variable "ci_runner_disk_size" {
   type        = string
   default     = "20"


### PR DESCRIPTION
At the moment, if you had a VPC with custom subnets it was not possible to use this module.

Now user can provide as a variable the subnet to put the instance on.

Tested with:

```
  ci_runner_network = "projects/my-project/global/networks/my-vpc"
  ci_runner_subnetwork = "personal-us-central1-pub-net"
```

And it created the instance fine.